### PR TITLE
Don't depend on valgrind on mips64el.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+libdbusmenu (18.10.20180917~bzr492+repack1-deepin2) unstable; urgency=medium
+
+  * debian/control:
+    + Don't depend on valgrind on mips64el.
+  * debian/patches:
+    + Add 0004_prevent-test-json-from-failing.patch. Prevent test-json from
+      failing due to 'Using cross-namespace EXTERNAL authentication' warning.
+      (Closes: #1020076).
+
+ -- qaqland <anguoli@uniontech.com>  Tue, 01 Jul 2025 10:35:31 +0800
+
 libdbusmenu (18.10.20180917~bzr492+repack1-deepin1) unstable; urgency=medium
 
   * Rebuild

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Build-Depends: dbus-test-runner,
  libx11-dev (>= 1.3),
  quilt,
  valac (>= 0.16),
- valgrind [!arm64 !ppc64el !armel !alpha !hppa !hurd-i386 !kfreebsd-amd64 !kfreebsd-i386 !m68k !powerpcspe !sh4 !sparc64 !x32 !ia64 !riscv64],
+ valgrind [!arm64 !ppc64el !armel !alpha !hppa !hurd-i386 !kfreebsd-amd64 !kfreebsd-i386 !m68k !powerpcspe !sh4 !sparc64 !x32 !ia64 !riscv64 !mips64el],
  xauth,
  xvfb,
 Standards-Version: 4.4.1

--- a/debian/patches/0004_prevent-test-json-from-failing.patch
+++ b/debian/patches/0004_prevent-test-json-from-failing.patch
@@ -1,0 +1,14 @@
+Origin: https://bazaar.launchpad.net/~dbusmenu-team/libdbusmenu/trunk.16.10/revision/497/tests/Makefile.am#tests/Makefile.am
+
+=== modified file 'tests/Makefile.am'
+--- a/tests/Makefile.am	2019-09-13 16:53:05 +0000
++++ b/tests/Makefile.am	2022-09-28 21:56:18 +0000
+@@ -219,6 +219,7 @@
+ 	@echo export G_MESSAGES_DEBUG=all >> $@
+ 	@echo $(XVFB_RUN) >> $@
+ 	@echo $(DBUS_RUNNER) --task ./test-json-client --wait-for org.dbusmenu.test --task-name Client --parameter $(top_builddir)/tools/dbusmenu-dumper --parameter test-json-01.output.json --task ./test-json-server --task-name Server --parameter $(srcdir)/test-json-01.json >> $@
++	@echo sed -i \"/Using cross-namespace EXTERNAL authentication \(this will deadlock if server is GDBus \< 2.73.3\)/d\" test-json-01.output.json >> $@
+ 	@echo diff $(srcdir)/test-json-01.json test-json-01.output.json \> /dev/null >> $@
+ 	@chmod +x $@
+ 
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 0001_no-deprecated-gnome-common-macros.patch
 0002_fix-ftbfs-gtk-doc-1-32.patch
 0003_port-tools-dbusmenu-bench-to-py3.patch
+0004_prevent-test-json-from-failing.patch


### PR DESCRIPTION
Valgrind cannot be used on this architecture. Remove dependency on Valgrind to skip the related [tests](https://github.com/deepin-community/libdbusmenu/blob/master/tests/test-json-instruction-count).

```
$ valgrind --version

valgrind: fatal error: unsupported CPU.
   Supported CPUs are:
   * x86 (practically any; Pentium-I or above), AMD Athlon or above)
   * AMD Athlon64/Opteron
   * ARM (armv7)
   * LoongArch (3A5000 and above)
   * MIPS (mips32 and above; mips64 and above)
   * PowerPC (most; ppc405 and above)
   * System z (64bit only - s390x; z990 and above)

```

---

Add 0004_prevent-test-json-from-failing.patch. Prevent test-json from failing due to 'Using cross-namespace EXTERNAL authentication' warning. (Closes: #1020076).

https://salsa.debian.org/debian-ayatana-team/libdbusmenu/-/commit/27f35880981fa6a670091dcd2df9938a0dd9c3fb