### PR TITLE
switch to valgrind-if-available, add sw64 support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libdbusmenu (18.10.20180917~bzr492+repack1-deepin3) unstable; urgency=medium
+
+  * debian/control:
+   + Switch to valgrind-if-available.
+
+ -- qaqland <anguoli@uniontech.com>  Fri, 04 Jul 2025 10:48:58 +0800
+
 libdbusmenu (18.10.20180917~bzr492+repack1-deepin2) unstable; urgency=medium
 
   * debian/control:

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Build-Depends: dbus-test-runner,
  libx11-dev (>= 1.3),
  quilt,
  valac (>= 0.16),
- valgrind [!arm64 !ppc64el !armel !alpha !hppa !hurd-i386 !kfreebsd-amd64 !kfreebsd-i386 !m68k !powerpcspe !sh4 !sparc64 !x32 !ia64 !riscv64 !mips64el],
+ valgrind-if-available,
  xauth,
  xvfb,
 Standards-Version: 4.4.1


### PR DESCRIPTION
wait https://github.com/deepin-community/valgrind-if-available/pull/1